### PR TITLE
Unit tests and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+config_parser
+config_parser_test
+config_parser.dSYM/
+gtest-all.*
+libgtest.*

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -169,7 +169,9 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
     if (token_type == TOKEN_TYPE_START) {
       // Error.
       break;
-    } else if (token_type == TOKEN_TYPE_NORMAL) {
+    }
+
+    else if (token_type == TOKEN_TYPE_NORMAL) {
       if (last_token_type == TOKEN_TYPE_START ||
           last_token_type == TOKEN_TYPE_STATEMENT_END ||
           last_token_type == TOKEN_TYPE_START_BLOCK ||
@@ -185,12 +187,16 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
         // Error.
         break;
       }
-    } else if (token_type == TOKEN_TYPE_STATEMENT_END) {
+    }
+
+    else if (token_type == TOKEN_TYPE_STATEMENT_END) {
       if (last_token_type != TOKEN_TYPE_NORMAL) {
         // Error.
         break;
       }
-    } else if (token_type == TOKEN_TYPE_START_BLOCK) {
+    }
+
+    else if (token_type == TOKEN_TYPE_START_BLOCK) {
       braces_count++;
       if (last_token_type != TOKEN_TYPE_NORMAL) {
         // Error.
@@ -200,27 +206,36 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
       config_stack.top()->statements_.back().get()->child_block_.reset(
           new_config);
       config_stack.push(new_config);
-    } else if (token_type == TOKEN_TYPE_END_BLOCK) {
+    }
+
+    else if (token_type == TOKEN_TYPE_END_BLOCK) {
       braces_count--;
-      if (last_token_type != TOKEN_TYPE_STATEMENT_END) {
+      if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
+        last_token_type != TOKEN_TYPE_START_BLOCK) {
         // Error.
         break;
       }
       config_stack.pop();
-    } else if (token_type == TOKEN_TYPE_EOF) {
+    }
+
+    else if (token_type == TOKEN_TYPE_EOF) {
       if (braces_count != 0) {
         return false;
       }
       if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
-          last_token_type != TOKEN_TYPE_END_BLOCK) {
+        last_token_type != TOKEN_TYPE_END_BLOCK &&
+        last_token_type != TOKEN_TYPE_START) {
         // Error.
         break;
       }
       return true;
-    } else {
+    }
+
+    else {
       // Error. Unknown token.
       break;
     }
+    
     last_token_type = token_type;
   }
 

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -149,6 +149,7 @@ NginxConfigParser::TokenType NginxConfigParser::ParseToken(std::istream* input,
 
 bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
   std::stack<NginxConfig*> config_stack;
+  int braces_count = 0;  
   config_stack.push(config);
   TokenType last_token_type = TOKEN_TYPE_START;
   TokenType token_type;
@@ -190,6 +191,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
         break;
       }
     } else if (token_type == TOKEN_TYPE_START_BLOCK) {
+      braces_count++;
       if (last_token_type != TOKEN_TYPE_NORMAL) {
         // Error.
         break;
@@ -199,12 +201,16 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
           new_config);
       config_stack.push(new_config);
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
+      braces_count--;
       if (last_token_type != TOKEN_TYPE_STATEMENT_END) {
         // Error.
         break;
       }
       config_stack.pop();
     } else if (token_type == TOKEN_TYPE_EOF) {
+      if (braces_count != 0) {
+        return false;
+      }
       if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
           last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -211,7 +211,8 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
     else if (token_type == TOKEN_TYPE_END_BLOCK) {
       braces_count--;
       if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
-        last_token_type != TOKEN_TYPE_START_BLOCK) {
+        last_token_type != TOKEN_TYPE_START_BLOCK &&
+        last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.
         break;
       }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -70,13 +70,16 @@ TEST_F(NginxStringConfigTest, ValidStatementNested) {
     EXPECT_EQ("buzz", GetChildStatementToken(1,0,1));
 }
 
-TEST_F(NginxStringConfigTest, ValidStatementEmptyNested) {
+TEST_F(NginxStringConfigTest, ValidEmptyConfig) {
+    ASSERT_TRUE(ParseString(""));
+}
+
+TEST_F(NginxStringConfigTest, ValidMultipleNestedConfigs) {
+    ASSERT_TRUE(ParseString("foo bar; server { foo bar; http {foo bar;} }"));
+}
+
+TEST_F(NginxStringConfigTest, ValidEmptyBlockStatement) {
     ASSERT_TRUE(ParseString("foo bar; server {}")); 
-    EXPECT_EQ(2, out_config_.statements_.size()) << "Config has 2 statements"; 
-    EXPECT_EQ("foo", GetToken(0,0));
-    EXPECT_EQ("bar", GetToken(0,1));
-    EXPECT_EQ("server", GetToken(1,0));
-    EXPECT_EQ("", GetChildStatementToken(1,0,0));
 }
 
 TEST_F(NginxStringConfigTest, InvalidSimpleStatement) {
@@ -87,11 +90,13 @@ TEST_F(NginxStringConfigTest, InvalidStatementMultipleSemiColon) {
     ASSERT_FALSE(ParseString("foo bar;;")); 
 }
 
-TEST_F(NginxStringConfigTest, InvalidStatementUnbalancedNested_1) {
+TEST_F(NginxStringConfigTest, InvalidStatementUnbalancedBraces_1) {
     ASSERT_FALSE(ParseString("foo bar; foo { foo bar; server { fizz buzz; }")); 
 }
 
-TEST_F(NginxStringConfigTest, InvalidStatementUnbalancedNested_2) {
+TEST_F(NginxStringConfigTest, InvalidStatementUnbalancedBraces_2) {
     ASSERT_FALSE(ParseString("foo bar; foo { foo bar; server { fizz buzz; { {")); 
 }
+
+
 

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -1,11 +1,94 @@
 #include "gtest/gtest.h"
 #include "config_parser.h"
 
-TEST(NginxConfigParserTest, SimpleConfig) {
+
+// Test Fixture: used to parse config statements passed in as strings
+// I.E. "foo bar;"
+class NginxStringConfigTest : public ::testing::Test {
+
+    protected:
+        bool ParseString(const std::string config_string) {
+            std::stringstream config_stream(config_string);
+            return parser_.Parse(&config_stream, &out_config_); 
+        }
+        
+        std::string GetToken(int statement_idx, int token_idx) {
+            if (statement_idx < 0 || token_idx < 0)
+                return NULL; 
+
+            return out_config_.statements_[statement_idx]->tokens_[token_idx];    
+        }
+
+        // Limited to a child statement depth of 1
+        std::string GetChildStatementToken(int statement_idx, int child_statement_idx, int token_idx) {
+            if (statement_idx < 0 || token_idx < 0 || child_statement_idx < 0)
+                return NULL;
+            return out_config_.statements_[statement_idx]->child_block_->statements_[child_statement_idx]->tokens_[token_idx];
+        }
+
+        NginxConfigParser parser_; 
+        NginxConfig out_config_; 
+}; 
+
+TEST(FileParsingTest, SimpleConfig) {
   NginxConfigParser parser;
   NginxConfig out_config;
 
   bool success = parser.Parse("example_config", &out_config);
 
   EXPECT_TRUE(success);
+  EXPECT_EQ(2, out_config.statements_.size());
+  EXPECT_EQ(3, out_config.statements_[1]->child_block_->statements_.size());
 }
+
+TEST_F(NginxStringConfigTest, ValidSimpleStatement) {
+    EXPECT_TRUE(ParseString("foo bar;")); 
+    EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statements"; 
+    EXPECT_EQ("foo", GetToken(0,0)); 
+}
+
+TEST_F(NginxStringConfigTest, ValidStatementWhitespace) {
+    EXPECT_TRUE(ParseString("foo             bar;")); 
+    EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statements"; 
+    EXPECT_EQ("foo", GetToken(0,0));
+    EXPECT_EQ("bar", GetToken(0,1)); 
+}
+
+TEST_F(NginxStringConfigTest, ValidStatementTab) {
+    EXPECT_TRUE(ParseString("foo	bar;")); 
+    EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statements"; 
+    EXPECT_EQ("foo", GetToken(0,0));
+    EXPECT_EQ("bar", GetToken(0,1)); 
+}
+
+TEST_F(NginxStringConfigTest, ValidStatementNested) {
+    ASSERT_TRUE(ParseString("foo bar; server { fizz buzz; }")); 
+    EXPECT_EQ(2, out_config_.statements_.size()) << "Config has 2 statements"; 
+    EXPECT_EQ("foo", GetToken(0,0));
+    EXPECT_EQ("bar", GetToken(0,1));
+    EXPECT_EQ("fizz", GetChildStatementToken(1,0,0));
+    EXPECT_EQ("buzz", GetChildStatementToken(1,0,1));
+}
+
+TEST_F(NginxStringConfigTest, ValidStatementEmptyNested) {
+    ASSERT_TRUE(ParseString("foo bar; server {}")); 
+    EXPECT_EQ(2, out_config_.statements_.size()) << "Config has 2 statements"; 
+    EXPECT_EQ("foo", GetToken(0,0));
+    EXPECT_EQ("bar", GetToken(0,1));
+    EXPECT_EQ("server", GetToken(1,0));
+    EXPECT_EQ("", GetChildStatementToken(1,0,0));
+}
+
+TEST_F(NginxStringConfigTest, InvalidSimpleStatement) {
+    ASSERT_FALSE(ParseString("foo bar")); 
+}
+
+TEST_F(NginxStringConfigTest, InvalidStatementMultipleSemiColon) {
+    ASSERT_FALSE(ParseString("foo bar;;")); 
+}
+
+TEST_F(NginxStringConfigTest, InvalidStatementUnblancedNested) {
+    ASSERT_FALSE(ParseString("foo bar; foo { foo bar; server { fizz buzz; }")); 
+}
+
+

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -43,20 +43,20 @@ TEST(FileParsingTest, SimpleConfig) {
 
 TEST_F(NginxStringConfigTest, ValidSimpleStatement) {
     EXPECT_TRUE(ParseString("foo bar;")); 
-    EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statements"; 
+    EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statement"; 
     EXPECT_EQ("foo", GetToken(0,0)); 
 }
 
 TEST_F(NginxStringConfigTest, ValidStatementWhitespace) {
     EXPECT_TRUE(ParseString("foo             bar;")); 
-    EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statements"; 
+    EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statement"; 
     EXPECT_EQ("foo", GetToken(0,0));
     EXPECT_EQ("bar", GetToken(0,1)); 
 }
 
 TEST_F(NginxStringConfigTest, ValidStatementTab) {
     EXPECT_TRUE(ParseString("foo	bar;")); 
-    EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statements"; 
+    EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statement"; 
     EXPECT_EQ("foo", GetToken(0,0));
     EXPECT_EQ("bar", GetToken(0,1)); 
 }
@@ -87,8 +87,11 @@ TEST_F(NginxStringConfigTest, InvalidStatementMultipleSemiColon) {
     ASSERT_FALSE(ParseString("foo bar;;")); 
 }
 
-TEST_F(NginxStringConfigTest, InvalidStatementUnblancedNested) {
+TEST_F(NginxStringConfigTest, InvalidStatementUnbalancedNested_1) {
     ASSERT_FALSE(ParseString("foo bar; foo { foo bar; server { fizz buzz; }")); 
 }
 
+TEST_F(NginxStringConfigTest, InvalidStatementUnbalancedNested_2) {
+    ASSERT_FALSE(ParseString("foo bar; foo { foo bar; server { fizz buzz; { {")); 
+}
 

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -36,7 +36,7 @@ TEST(FileParsingTest, SimpleConfig) {
 
   bool success = parser.Parse("example_config", &out_config);
 
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(success) << "Valid config files should be parsed successfully";
   EXPECT_EQ(2, out_config.statements_.size());
   EXPECT_EQ(3, out_config.statements_[1]->child_block_->statements_.size());
 }
@@ -48,14 +48,14 @@ TEST_F(NginxStringConfigTest, ValidSimpleStatement) {
 }
 
 TEST_F(NginxStringConfigTest, ValidStatementWhitespace) {
-    EXPECT_TRUE(ParseString("foo             bar;")); 
-    EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statement"; 
+    EXPECT_TRUE(ParseString("foo             bar;"))  << "Config statements with additional white space should be parsed successfully";
+    EXPECT_EQ(1, out_config_.statements_.size()); 
     EXPECT_EQ("foo", GetToken(0,0));
     EXPECT_EQ("bar", GetToken(0,1)); 
 }
 
 TEST_F(NginxStringConfigTest, ValidStatementTab) {
-    EXPECT_TRUE(ParseString("foo	bar;")); 
+    EXPECT_TRUE(ParseString("foo	bar;")) << "Config statements with tabbing should be parsed successfully";
     EXPECT_EQ(1, out_config_.statements_.size()) << "Config has one statement"; 
     EXPECT_EQ("foo", GetToken(0,0));
     EXPECT_EQ("bar", GetToken(0,1)); 
@@ -71,15 +71,15 @@ TEST_F(NginxStringConfigTest, ValidStatementNested) {
 }
 
 TEST_F(NginxStringConfigTest, ValidEmptyConfig) {
-    ASSERT_TRUE(ParseString(""));
+    ASSERT_TRUE(ParseString("")) << "Empty config files should still be parseable";
 }
 
 TEST_F(NginxStringConfigTest, ValidMultipleNestedConfigs) {
-    ASSERT_TRUE(ParseString("foo bar; server { foo bar; http {foo bar;} }"));
+    ASSERT_TRUE(ParseString("foo bar; server { foo bar; http {foo bar;} }")) << "Config statements with multiple child blocks should be parsed successfully";
 }
 
 TEST_F(NginxStringConfigTest, ValidEmptyBlockStatement) {
-    ASSERT_TRUE(ParseString("foo bar; server {}")); 
+    ASSERT_TRUE(ParseString("foo bar; server {}")) << "Empty config blocks should be parsed successfully";
 }
 
 TEST_F(NginxStringConfigTest, InvalidSimpleStatement) {
@@ -91,11 +91,11 @@ TEST_F(NginxStringConfigTest, InvalidStatementMultipleSemiColon) {
 }
 
 TEST_F(NginxStringConfigTest, InvalidStatementUnbalancedBraces_1) {
-    ASSERT_FALSE(ParseString("foo bar; foo { foo bar; server { fizz buzz; }")); 
+    ASSERT_FALSE(ParseString("foo bar; foo { foo bar; server { fizz buzz; }")) << "Curly braces must be balanced"; 
 }
 
 TEST_F(NginxStringConfigTest, InvalidStatementUnbalancedBraces_2) {
-    ASSERT_FALSE(ParseString("foo bar; foo { foo bar; server { fizz buzz; { {")); 
+    ASSERT_FALSE(ParseString("foo bar; foo { foo bar; server { fizz buzz; { {")) << "Curly braces must be balanced";
 }
 
 


### PR DESCRIPTION
Bug fixes: 
- Checks for unbalanced braces
-  Empty config files can still be parsed
- Multiple nested blocks are parseable 