### PR TITLE
Unit tests

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -199,7 +199,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
           new_config);
       config_stack.push(new_config);
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
-      if (last_token_type != TOKEN_TYPE_STATEMENT_END) {
+      if (last_token_type != TOKEN_TYPE_STATEMENT_END && last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.
         break;
       }

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -199,9 +199,14 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
           new_config);
       config_stack.push(new_config);
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
-      if (last_token_type != TOKEN_TYPE_STATEMENT_END && last_token_type != TOKEN_TYPE_END_BLOCK) {
+      if ((last_token_type != TOKEN_TYPE_STATEMENT_END && last_token_type != TOKEN_TYPE_END_BLOCK) ) { 
         // Error.
         break;
+      }
+      else if (config_stack.size() <= 1) //try to pop when that is not allowed (not enough elements on stack)
+      {
+        printf ("Unbalanced curly braces: too many right curly braces\n");
+        return false;
       }
       config_stack.pop();
     } else if (token_type == TOKEN_TYPE_EOF) {
@@ -213,7 +218,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
       else if (config_stack.size() != 1) 
       {
           //error, failed to find token type end before reaching end
-        printf ("Unbalanced curly braces\n");
+        printf ("Unbalanced curly braces: too many left curly braces\n");
         return false;
       }
       return true;

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -210,6 +210,12 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
         // Error.
         break;
       }
+      else if (config_stack.size() != 1) 
+      {
+          //error, failed to find token type end before reaching end
+        printf ("Unbalanced curly braces\n");
+        return false;
+      }
       return true;
     } else {
       // Error. Unknown token.

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -76,6 +76,8 @@ TEST_F(NginxConfigParserStringTest, CurlyConfig) {
 TEST_F(NginxConfigParserStringTest, UnbalancedCurlyConfig) {
 	EXPECT_FALSE(ParseString("foo bar {foo bar; "));
 	EXPECT_FALSE(ParseString("foo bar {foo bar {foo bar; }"));
+	EXPECT_FALSE(ParseString("foo bar foo bar; } } }"));
+
 
 }
 

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -44,27 +44,28 @@ TEST_F(NginxConfigParserStringTest, SimpleConfig1) {
 	
 }
 
-TEST_F(NginxConfigParserStringTest, InvalidConfig) {
+TEST_F(NginxConfigParserStringTest, SimpleInvalidConfig) {
 
 	EXPECT_FALSE(ParseString("foo bar"));
+	EXPECT_FALSE(ParseString("foo bar;;"));
+	EXPECT_FALSE(ParseString("foo bar {}"));
 	
   
 }
 
 TEST_F(NginxConfigParserStringTest, MultipleStatements) {
 	ASSERT_TRUE(ParseString("foo bar {foo bar; } foobar;"));
-	// printf("adsfsdf%s\n", out_config_.ToString().c_str());
-	EXPECT_EQ(2, out_config_.statements_.size());
+	ASSERT_EQ(2, out_config_.statements_.size());
+	EXPECT_EQ("foo bar {\n  foo bar;\n}\n", out_config_.statements_[0]->ToString(0));
 
 }
 
 TEST_F(NginxConfigParserStringTest, InnerStatement) {
 	ASSERT_TRUE(ParseString("foo bar {foo barr; bar foo;} foobar;"));
-	// printf("adsfsdf%s\n", out_config_.ToString().c_str());
 	ASSERT_EQ(2, out_config_.statements_.size());
-	EXPECT_EQ(2, out_config_.statements_[0].get()->child_block_->statements_.size());
-	//printf("%s\n", out_config_.statements_[0].get()->child_block_->statements_[1]->ToString(0).c_str());
-
+	ASSERT_EQ(2, out_config_.statements_[0]->child_block_->statements_.size());
+	EXPECT_EQ("bar foo;\n", out_config_.statements_[0]->child_block_->statements_[1]->ToString(0));
+	EXPECT_EQ("foo barr;\n", out_config_.statements_[0]->child_block_->statements_[0]->ToString(0));
 }
 
 TEST_F(NginxConfigParserStringTest, CurlyConfig) {
@@ -73,7 +74,7 @@ TEST_F(NginxConfigParserStringTest, CurlyConfig) {
 
 }
 
-TEST_F(NginxConfigParserStringTest, UnbalancedCurlyConfig) {
+TEST_F(NginxConfigParserStringTest, UnbalancedCurlyConfigs) {
 	EXPECT_FALSE(ParseString("foo bar {foo bar; "));
 	EXPECT_FALSE(ParseString("foo bar {foo bar {foo bar; }"));
 	EXPECT_FALSE(ParseString("foo bar foo bar; } } }"));
@@ -84,10 +85,7 @@ TEST_F(NginxConfigParserStringTest, UnbalancedCurlyConfig) {
 TEST_F(NginxConfigParserStringTest, EmbedCurlyConfig) {
 	ASSERT_TRUE(ParseString("foo bar { foo bar {fooo bar;} }"));
 	ASSERT_EQ(1, out_config_.statements_.size());
-	ASSERT_EQ(1, out_config_.statements_[0].get()->child_block_->statements_.size());
-	EXPECT_EQ(1, out_config_.statements_[0].get()->child_block_->statements_[0].get()->child_block_->statements_.size());
-	// printf("%s\n", out_config_.statements_[0].get()->child_block_->statements_[0]->ToString(0).c_str());
-	printf("%s\n", out_config_.statements_[0].get()->child_block_->statements_[0].get()->child_block_->statements_[0]->ToString(0).c_str());
-
-
+	ASSERT_EQ(1, out_config_.statements_[0]->child_block_->statements_.size());
+	EXPECT_EQ(1, out_config_.statements_[0]->child_block_->statements_[0].get()->child_block_->statements_.size());
+	
 }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -1,11 +1,85 @@
 #include "gtest/gtest.h"
 #include "config_parser.h"
 
+
+
+class NginxConfigParserStringTest : public ::testing::Test {
+protected:
+ 	bool ParseString(const std::string config_string) {
+ 		std::stringstream config_stream(config_string);
+ 		return parser_.Parse(&config_stream, &out_config_);
+ 	}
+ 	NginxConfigParser parser_;
+ 	NginxConfig out_config_;
+ };
+
+
+
 TEST(NginxConfigParserTest, SimpleConfig) {
   NginxConfigParser parser;
   NginxConfig out_config;
 
-  bool success = parser.Parse("example_config", &out_config);
+	bool success = parser.Parse("example_config", &out_config);
 
-  EXPECT_TRUE(success);
+	EXPECT_TRUE(success);
+}
+
+
+
+
+TEST(NginxConfigStatementTest, ToString) {
+	NginxConfigStatement statement;
+	statement.tokens_.push_back("foo");
+	statement.tokens_.push_back("bar");
+	EXPECT_EQ("foo bar;\n", statement.ToString(0));
+}
+
+TEST_F(NginxConfigParserStringTest, SimpleConfig1) {
+
+	
+	ASSERT_TRUE(ParseString("foo bar;"));
+	ASSERT_EQ(1, out_config_.statements_.size());
+	EXPECT_EQ("foo", out_config_.statements_[0]->tokens_[0]);
+  
+	
+}
+
+TEST_F(NginxConfigParserStringTest, InvalidConfig) {
+
+	EXPECT_FALSE(ParseString("foo bar"));
+	
+  
+}
+
+TEST_F(NginxConfigParserStringTest, MultipleStatements) {
+	ASSERT_TRUE(ParseString("foo bar {foo bar; } foobar;"));
+	// printf("adsfsdf%s\n", out_config_.ToString().c_str());
+	EXPECT_EQ(2, out_config_.statements_.size());
+
+}
+
+TEST_F(NginxConfigParserStringTest, InnerStatement) {
+	ASSERT_TRUE(ParseString("foo bar {foo barr; } foobar;"));
+	// printf("adsfsdf%s\n", out_config_.ToString().c_str());
+	EXPECT_EQ(2, out_config_.statements_.size());
+	EXPECT_EQ(1, out_config_.statements_[0].get()->child_block_->statements_.size());
+	printf("%s\n", out_config_.statements_[0].get()->child_block_->statements_[0]->ToString(0).c_str());
+
+}
+
+TEST_F(NginxConfigParserStringTest, CurlyConfig) {
+	ASSERT_TRUE(ParseString("foo bar {foo bar; foo bar;}"));
+	EXPECT_EQ(1, out_config_.statements_.size());
+
+}
+
+TEST_F(NginxConfigParserStringTest, UnbalancedCurlyConfig) {
+	EXPECT_FALSE(ParseString("foo bar {foo bar; "));
+
+}
+
+TEST_F(NginxConfigParserStringTest, EmbedCurlyConfig) {
+	EXPECT_TRUE(ParseString("foo bar { foo bar {foo bar;} }"));
+
+
 }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -59,11 +59,11 @@ TEST_F(NginxConfigParserStringTest, MultipleStatements) {
 }
 
 TEST_F(NginxConfigParserStringTest, InnerStatement) {
-	ASSERT_TRUE(ParseString("foo bar {foo barr; } foobar;"));
+	ASSERT_TRUE(ParseString("foo bar {foo barr; bar foo;} foobar;"));
 	// printf("adsfsdf%s\n", out_config_.ToString().c_str());
-	EXPECT_EQ(2, out_config_.statements_.size());
-	EXPECT_EQ(1, out_config_.statements_[0].get()->child_block_->statements_.size());
-	printf("%s\n", out_config_.statements_[0].get()->child_block_->statements_[0]->ToString(0).c_str());
+	ASSERT_EQ(2, out_config_.statements_.size());
+	EXPECT_EQ(2, out_config_.statements_[0].get()->child_block_->statements_.size());
+	//printf("%s\n", out_config_.statements_[0].get()->child_block_->statements_[1]->ToString(0).c_str());
 
 }
 
@@ -75,11 +75,17 @@ TEST_F(NginxConfigParserStringTest, CurlyConfig) {
 
 TEST_F(NginxConfigParserStringTest, UnbalancedCurlyConfig) {
 	EXPECT_FALSE(ParseString("foo bar {foo bar; "));
+	EXPECT_FALSE(ParseString("foo bar {foo bar {foo bar; }"));
 
 }
 
 TEST_F(NginxConfigParserStringTest, EmbedCurlyConfig) {
-	EXPECT_TRUE(ParseString("foo bar { foo bar {foo bar;} }"));
+	ASSERT_TRUE(ParseString("foo bar { foo bar {fooo bar;} }"));
+	ASSERT_EQ(1, out_config_.statements_.size());
+	ASSERT_EQ(1, out_config_.statements_[0].get()->child_block_->statements_.size());
+	EXPECT_EQ(1, out_config_.statements_[0].get()->child_block_->statements_[0].get()->child_block_->statements_.size());
+	// printf("%s\n", out_config_.statements_[0].get()->child_block_->statements_[0]->ToString(0).c_str());
+	printf("%s\n", out_config_.statements_[0].get()->child_block_->statements_[0].get()->child_block_->statements_[0]->ToString(0).c_str());
 
 
 }


### PR DESCRIPTION
Wrote unit tests to test the config parser

Made a couple changes to the config parser:
- fixed bugs with unbalanced curly braces - they were legal in the config parser when they should be flagged instead
  - fix took advantage of the stack already present, checking its size when EOF or when adding closed curly braces to ensure it stays in a valid state
- multiple closed curly braces were allowed to allow embedded config files
  