### PR TITLE
Unit tests

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -205,6 +205,10 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
         // Error.
         break;
       }
+	  if (config_stack.size() == 1) {
+		  // Error - unexpected }
+		  break;
+	  }
       config_stack.pop();
     } else if (token_type == TOKEN_TYPE_EOF) {
       if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
@@ -212,6 +216,10 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
         // Error.
         break;
       }
+	  if (config_stack.size() != 1) {
+		  // Error - expected more }
+		  break;
+	  }
       return true;
     } else {
       // Error. Unknown token.

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -199,7 +199,9 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
           new_config);
       config_stack.push(new_config);
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
-      if (last_token_type != TOKEN_TYPE_STATEMENT_END) {
+      if (last_token_type != TOKEN_TYPE_STATEMENT_END && 
+		  last_token_type != TOKEN_TYPE_START_BLOCK &&
+		  last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.
         break;
       }

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -200,15 +200,15 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
       config_stack.push(new_config);
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
       if (last_token_type != TOKEN_TYPE_STATEMENT_END && 
-		  last_token_type != TOKEN_TYPE_START_BLOCK &&
-		  last_token_type != TOKEN_TYPE_END_BLOCK) {
+      last_token_type != TOKEN_TYPE_START_BLOCK &&
+      last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.
         break;
       }
-	  if (config_stack.size() == 1) {
-		  // Error - unexpected }
-		  break;
-	  }
+    if (config_stack.size() == 1) {
+      // Error - unexpected }
+      break;
+    }
       config_stack.pop();
     } else if (token_type == TOKEN_TYPE_EOF) {
       if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
@@ -216,10 +216,10 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
         // Error.
         break;
       }
-	  if (config_stack.size() != 1) {
-		  // Error - expected more }
-		  break;
-	  }
+    if (config_stack.size() != 1) {
+      // Error - expected more }
+      break;
+    }
       return true;
     } else {
       // Error. Unknown token.

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "config_parser.h"
+#include <sstream>
 
 TEST(NginxConfigParserTest, SimpleConfig) {
   NginxConfigParser parser;
@@ -9,3 +10,49 @@ TEST(NginxConfigParserTest, SimpleConfig) {
 
   EXPECT_TRUE(success);
 }
+
+class NginxStringParserTest : public ::testing::Test {
+protected:
+
+	bool parseString(const std::string& str) {
+		std::stringstream ss(str);
+		return parser.Parse(&ss, &out_config);
+	}
+	NginxConfigParser parser;
+	NginxConfig out_config;
+};
+
+// Simple statements
+TEST_F(NginxStringParserTest, ParseStatements) {
+	EXPECT_TRUE(parseString("http1.1;"));
+	EXPECT_TRUE(parseString("version 1.1;"));
+	EXPECT_TRUE(parseString("version 1.1;\nrevision 4;\n"));
+}
+
+// Are empty {} allowed?
+TEST_F(NginxStringParserTest, ParseContextEmpty) {
+	EXPECT_TRUE(parseString("Events {\n}"));
+}
+
+// Sanity check {}
+TEST_F(NginxStringParserTest, ParseContextSimple) {
+	EXPECT_TRUE(parseString("html { port 4000; }"));
+	EXPECT_TRUE(parseString("location /images/ { root /data/; }"));
+}
+
+// Multiple nesting
+TEST_F(NginxStringParserTest, ParseContextDeep) {
+	EXPECT_TRUE(parseString("server { location { root /data; }}"));
+}
+
+// Unbalanced curly braces
+TEST_F(NginxStringParserTest, ParseUnbalanced) {
+	EXPECT_FALSE(parseString("server { hello; }}"));
+	EXPECT_FALSE(parseString("server { hello;"));
+}
+
+//// Just C++ things... abusing the unique_ptr
+//TEST(NginxConfigParserTest, StatementCopyTest) {
+//	ASSERT_TRUE(parseString("simple;"));
+//	NginxConfigStatement stmt = 
+//}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -14,45 +14,95 @@ TEST(NginxConfigParserTest, SimpleConfig) {
 class NginxStringParserTest : public ::testing::Test {
 protected:
 
-	bool parseString(const std::string& str) {
-		std::stringstream ss(str);
-		return parser.Parse(&ss, &out_config);
-	}
-	NginxConfigParser parser;
-	NginxConfig out_config;
+  bool parseString(const std::string& str) {
+    std::stringstream ss(str);
+    return parser.Parse(&ss, &out_config);
+  }
+  NginxConfigParser parser;
+  NginxConfig out_config;
 };
 
 // Simple statements
 TEST_F(NginxStringParserTest, ParseStatements) {
-	EXPECT_TRUE(parseString("http1.1;"));
-	EXPECT_TRUE(parseString("version 1.1;"));
-	EXPECT_TRUE(parseString("version 1.1;\nrevision 4;\n"));
+  EXPECT_TRUE(parseString("http1.1;"));
+  EXPECT_TRUE(parseString("version 1.1;"));
+  EXPECT_TRUE(parseString("version 1.1;\nrevision 4;\n"));
 }
 
 // Are empty {} allowed?
 TEST_F(NginxStringParserTest, ParseContextEmpty) {
-	EXPECT_TRUE(parseString("Events {\n}"));
+  EXPECT_TRUE(parseString("Events {\n}"));
 }
 
 // Sanity check {}
 TEST_F(NginxStringParserTest, ParseContextSimple) {
-	EXPECT_TRUE(parseString("html { port 4000; }"));
-	EXPECT_TRUE(parseString("location /images/ { root /data/; }"));
+  EXPECT_TRUE(parseString("html { port 4000; }"));
+  EXPECT_TRUE(parseString("location /images/ { root /data/; }"));
+  EXPECT_TRUE(parseString("html{port 1234;}"));
+  EXPECT_TRUE(parseString("html\t\t\n{\t\nport 1234;\n\t}\n"));
 }
 
 // Multiple nesting
 TEST_F(NginxStringParserTest, ParseContextDeep) {
-	EXPECT_TRUE(parseString("server { location { root /data; }}"));
+  EXPECT_TRUE(parseString("server { location { root /data; }}"));
 }
 
 // Unbalanced curly braces
 TEST_F(NginxStringParserTest, ParseUnbalanced) {
-	EXPECT_FALSE(parseString("server { hello; }}"));
-	EXPECT_FALSE(parseString("server { hello;"));
+  EXPECT_FALSE(parseString("server { hello; }}"));
+  EXPECT_FALSE(parseString("server { hello;"));
 }
 
-//// Just C++ things... abusing the unique_ptr
-//TEST(NginxConfigParserTest, StatementCopyTest) {
-//	ASSERT_TRUE(parseString("simple;"));
-//	NginxConfigStatement stmt = 
-//}
+// Token test
+TEST_F(NginxStringParserTest, ParseTokenCheck) {
+  parseString("one two three four;");
+  EXPECT_EQ(out_config.statements_[0]->tokens_, std::vector<std::string>({ "one", "two", "three", "four" }));
+}
+
+// Structure and Content test
+TEST_F(NginxStringParserTest, ParseCheckStructure) {
+  std::string str =
+    "server {\n"
+    "  zero {\n"
+    "    0;\n"
+    "    1;\n"
+    "  }\n"
+    "  one {\n"
+    "    0;\n"
+    "    1;\n"
+    "  }\n"
+    "  two {\n"
+    "  }\n"
+    "}\n";
+  ASSERT_TRUE(parseString(str));
+
+  // check
+  ASSERT_EQ(str, out_config.ToString(0)); // printing
+  // check root tokens
+  ASSERT_TRUE(out_config.statements_[0]->tokens_ == std::vector<std::string>{ "server" });
+  // check root children
+  ASSERT_EQ(out_config.statements_.size(), 1); 
+
+
+  // check children (zero, one, two)
+  auto childptr = out_config.statements_[0]->child_block_.get();
+
+  ASSERT_EQ(childptr->statements_.size(), 3);
+  EXPECT_TRUE(childptr->statements_[0]->tokens_ == std::vector<std::string>{ "zero" });
+  EXPECT_TRUE(childptr->statements_[1]->tokens_ == std::vector<std::string>{ "one" });
+  EXPECT_TRUE(childptr->statements_[2]->tokens_ == std::vector<std::string>{ "two" });
+  
+
+  // children's children (0,1)
+  EXPECT_EQ(childptr->statements_[0]->child_block_->statements_.size(), 2);
+  EXPECT_EQ(childptr->statements_[1]->child_block_->statements_.size(), 2);
+  EXPECT_EQ(childptr->statements_[2]->child_block_->statements_.size(), 0);
+
+  // children's children's tokens
+  EXPECT_TRUE(childptr->statements_[0]->child_block_->statements_[0]->tokens_ == std::vector<std::string>{ "0" });
+
+  // side note - auto childptr = out_config.statements_[0]->child_block_; 
+  //  is illegal since we can't have copies of a unique pointer -> we can't
+  //  use the copy constructor or assignment op
+  // a preference kind of thing?
+}


### PR DESCRIPTION
Basic unit tests for
- NginxConfig::ToString
- NginxConfigParser::Parse

Fixes the following features:
- contexts { } require balanced curly braces
- contexts can be nested
- contexts can be empty